### PR TITLE
Make code Python 3 friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.swp
 *~
+ndtest

--- a/ndfilehandler.py
+++ b/ndfilehandler.py
@@ -18,7 +18,7 @@ import os
 def read_file_helper(fn,objt):
     ff  = open(fn,"r")
     ndim = N.fromfile(ff,count=1,dtype='<i4')
-    dims = N.fromfile(ff,count=ndim,dtype='<i8')
+    dims = N.fromfile(ff,count=ndim[0],dtype='<i8')
     nobj = N.prod(dims)
     ret=N.fromfile(ff,count=nobj,dtype=objt)
     ff.close()
@@ -41,7 +41,7 @@ def read_file(fname,keys=None):
         # Get the field name and type.
         mm = re.search(fname+"/"+r"(\w*)\.nd\.([fi][48])",fn)
         if mm==None:
-            raise RuntimeError,"Unable to parse file "+fn
+            raise RuntimeError("Unable to parse file "+fn)
         else:
             key = mm.group(1)
             objt= mm.group(2)
@@ -55,7 +55,7 @@ def read_file(fname,keys=None):
     if keys!=None:
         for key in keys:
             if key not in ret.keys():
-                raise RuntimeError,"Unable to find "+key+" in "+fname
+                raise RuntimeError("Unable to find "+key+" in "+fname)
     return(ret)
     #
 

--- a/test_ndfilehandler.py
+++ b/test_ndfilehandler.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from ndfilehandler import read_file, write_file;
 import numpy as np
 
@@ -9,6 +10,6 @@ write_file("ndtest",data)
 
 ## Read in the file
 data2 = read_file("ndtest",None)
-print data['farr']==data2['farr']
-print data['iarr']==data2['iarr']
-print data2['iarr'].shape
+print(data['farr']==data2['farr'])
+print(data['iarr']==data2['iarr'])
+print(data2['iarr'].shape)


### PR DESCRIPTION
Fix a few issues
* Raise is now a Python 2/3 friendly form
* print function in test code
* pass the first element of ndim when reading dimensions, to avoid errors and DeprecationWarnings.

Also, for fun --
* ignore the test directory.